### PR TITLE
Servlet

### DIFF
--- a/servlet/src/main/java/com/example/CharacterEncodingFilter.java
+++ b/servlet/src/main/java/com/example/CharacterEncodingFilter.java
@@ -10,7 +10,7 @@ public class CharacterEncodingFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        request.getServletContext().log("doFilter() 호출");
+        request.getServletContext().log("CharacterEncodingFilter.doFilter, doFilter() 호출");
         chain.doFilter(request, response);
     }
 }

--- a/servlet/src/main/java/com/example/KoreanServlet.java
+++ b/servlet/src/main/java/com/example/KoreanServlet.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 @WebServlet(name = "koreanServlet", urlPatterns = "/korean")
 public class KoreanServlet extends HttpServlet {
@@ -23,6 +25,7 @@ public class KoreanServlet extends HttpServlet {
     @Override
     protected void service(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         getServletContext().log("service() 호출");
+        response.setCharacterEncoding("UTF-8");
         response.getWriter().write(인코딩);
     }
 

--- a/servlet/src/main/java/com/example/LocalCounterServlet.java
+++ b/servlet/src/main/java/com/example/LocalCounterServlet.java
@@ -24,10 +24,10 @@ public class LocalCounterServlet extends HttpServlet {
      */
     @Override
     protected void service(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        getServletContext().log("service() 호출");
         response.addHeader("Content-Type", "text/html; charset=utf-8");
         int localCounter = 0;
         localCounter++;
+        getServletContext().log("service() 호출, localCounter: " + localCounter);
         response.getWriter().write(String.valueOf(localCounter));
     }
 

--- a/servlet/src/main/java/com/example/SharedCounterServlet.java
+++ b/servlet/src/main/java/com/example/SharedCounterServlet.java
@@ -41,8 +41,8 @@ public class SharedCounterServlet extends HttpServlet {
 
     @Override
     protected void service(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        getServletContext().log("service() 호출");
         sharedCounter++;
+        getServletContext().log("service() 호출, sharedCounter: " + sharedCounter);
         response.getWriter().write(String.valueOf(sharedCounter));
     }
 

--- a/servlet/src/test/java/com/example/ServletTest.java
+++ b/servlet/src/test/java/com/example/ServletTest.java
@@ -25,7 +25,7 @@ class ServletTest {
 
         // expected를 0이 아닌 올바른 값으로 바꿔보자.
         // 예상한 결과가 나왔는가? 왜 이런 결과가 나왔을까?
-        assertThat(Integer.parseInt(response.body())).isEqualTo(0);
+        assertThat(Integer.parseInt(response.body())).isEqualTo(3);
     }
 
     @Test
@@ -47,6 +47,6 @@ class ServletTest {
 
         // expected를 0이 아닌 올바른 값으로 바꿔보자.
         // 예상한 결과가 나왔는가? 왜 이런 결과가 나왔을까?
-        assertThat(Integer.parseInt(response.body())).isEqualTo(0);
+        assertThat(Integer.parseInt(response.body())).isEqualTo(1);
     }
 }


### PR DESCRIPTION
https://github.com/euichaan/TIL/blob/main/spring/servlet/servlet.md

컨테이너는 서블릿 하나로 다수의 요청을 처리하기 위하여 다수의 스레드를 실행합니다. (다수의 인스턴스를 만들지 않습니다)
서블릿 객체는 하나인데, 쓰레드가 여러개라면 `동시성 이슈`가 발생할 가능성이 있습니다. 이런 구조상 `Thread-Safe`를 위해 서블릿은 상태(인스턴스 변수 및 static 변수)를 가지면 안됩니다.

서블릿이 상태를 가지면, 공유 자원으로 인한 동시성 이슈가 발생해 사용자의 민감한 정보가 다른 사용자에게 노출되는 일이 발생할 수도 있습니다.

`init()` -> `doFilter()` -> `service()` -> `destroy()` 순으로 호출 

MIME 본문 응답에 대한 문자셋은 명시적으로 지정하거나 암시적으로 지정할 수 있습니다.

**명시적 지정**
- setCharacterEncoding
- setContentType

**암시적 지정**
- setLocale

명시적이 암시적 보다 우선합니다. 문자셋을 지정하지 않으면 ISO-8859-1이 사용됩니다.
ISO-8859-1은 한글을 포함한 많은 비서유럽 언어의 문자를 지원하지 않습니다.
 
